### PR TITLE
Typos in imports

### DIFF
--- a/script/deployChainlinkDSPortal.s.sol
+++ b/script/deployChainlinkDSPortal.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 
 import "forge-std/Script.sol";
 import "../src/oracle/ChainlinkDS.sol";
-import "./Utils.s.sol";
+import "./utils.s.sol";
 
 contract ChainlinkDSPortalScript is Script {
     // add this to be excluded from coverage report

--- a/script/deployFundingRateLimiterZK.s.sol
+++ b/script/deployFundingRateLimiterZK.s.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.19;
 
 import "../lib/forge-std/src/Script.sol";
-import "../src/fundingRateLimiter/FundingRateUpdateLimiterZK.sol";
+import "../src/fundingRateLimiter/FundingRateUpdateLimiterZk.sol";
 import "./utils.s.sol";
 
 contract FundingRateUpdateLimiterZKMain is Script {


### PR DESCRIPTION
Typos in two different imports in two different files.

Fixing the typos makes all the tests pass.